### PR TITLE
[UPDATE] Update footer year and adjust form contact email styles

### DIFF
--- a/src/app/components/footer-contact/footer-contact.component.html
+++ b/src/app/components/footer-contact/footer-contact.component.html
@@ -14,6 +14,6 @@
         </div>
     </div>
     <div class="footer-bottom">
-        <p>© 2024 Hugo-GS. Todos los derechos reservados.</p>
+        <p>© 2025 Hugo-GS. Todos los derechos reservados.</p>
     </div>
 </footer>

--- a/src/app/components/form-contact-email/form-contact-email.component.css
+++ b/src/app/components/form-contact-email/form-contact-email.component.css
@@ -54,7 +54,7 @@ legend {
   position: relative;
   margin-bottom: 20px;
   width: 100%;
-  height: 53px;
+  height: 57px;
   border: var(--weight-border) solid var(--color-bg_visual_yellow);
   overflow: hidden;
   border-radius: 5px;
@@ -87,7 +87,7 @@ legend {
   background-color: transparent;
   color: var(--color-blue-aqua);
   border-radius: 5px;
-  padding: 0 10px;
+  padding: 14px 10px 16px 10px;
   font-family: "Ubuntu", sans-serif;
 }
 .form-field textarea {


### PR DESCRIPTION
- Changed footer copyright year from 2024 to 2025.
- Increased height of the legend element in form-contact-email component from 53px to 57px.
- Adjusted padding in the legend element for better spacing.